### PR TITLE
Add examples for K8S deployment

### DIFF
--- a/deploy/nats-mq.yaml
+++ b/deploy/nats-mq.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats-mq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: nats-mq
+  template:
+    metadata:
+      labels:
+        name: nats-mq
+    spec:
+      containers:
+      - name: nats-mq
+        image: connecteverything/mq-bridge:0.5
+        imagePullPolicy: Always
+        command:
+        - /go/bin/nats-mq
+        - -c
+        - /etc/nats-mq/nats-mq.conf
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nats-mq/
+      volumes:
+        - name: config
+          configMap:
+            name: nats-mq-conf
+---
+apiVersion: "nats.io/v1alpha2"
+kind: NatsCluster
+metadata:
+  name: "nats-mq-svc"
+spec:
+  size: 3
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nats-mq-conf
+data:
+  nats-mq.conf: |
+    nats {
+      Servers ["nats-mq-svc:4222"]
+    }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nats-operator
+  # Change to the name of the namespace where to install NATS Operator.
+  # Alternatively, change to "nats-io" to perform a cluster-scoped deployment in supported versions.
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: nats-operator
+  template:
+    metadata:
+      labels:
+        name: nats-operator
+    spec:
+      serviceAccountName: nats-operator
+      containers:
+      - name: nats-operator
+        image: connecteverything/nats-operator:0.4.4-v1alpha2
+        imagePullPolicy: IfNotPresent
+        args:
+        - nats-operator
+        # Uncomment to perform a cluster-scoped deployment in supported versions.
+        #- --feature-gates=ClusterScoped=true
+        ports:
+        - name: readyz
+          containerPort: 8080
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: readyz
+          initialDelaySeconds: 15
+          timeoutSeconds: 3

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-operator
+  # Change to the name of the namespace where to install NATS Operator.
+  # Alternatively, change to "nats-io" to perform a cluster-scoped deployment in supported versions.
+  namespace: default
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-operator-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-operator
+subjects:
+- kind: ServiceAccount
+  name: nats-operator
+  # Change to the name of the namespace where to install NATS Operator.
+  # Alternatively, change to "nats-io" to perform a cluster-scoped deployment in supported versions.
+  namespace: default
+
+# NOTE: When performing multiple namespace-scoped installations, all
+# "nats-operator" service accounts (across the different namespaces)
+# MUST be added to this binding.
+#- kind: ServiceAccount
+#  name: nats-operator
+#  namespace: nats-io
+#- kind: ServiceAccount
+#  name: nats-operator
+#  namespace: namespace-2
+#(...)
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-operator
+rules:
+# Allow creating CRDs
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["get", "list", "create", "update", "watch"]
+
+# Allow all actions on NATS Operator manager CRDs
+- apiGroups:
+  - nats.io
+  resources:
+  - natsclusters
+  - natsserviceroles
+  verbs: ["*"]
+
+# Allowed actions on Pods
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
+
+# Allowed actions on Services
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["create", "watch", "get", "patch", "update", "delete", "list"]
+
+# Allowed actions on Secrets
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["create", "watch", "get", "update", "delete", "list"]
+
+# Allow all actions on some special subresources
+- apiGroups: [""]
+  resources:
+  - pods/exec
+  - pods/log
+  - serviceaccounts/token
+  - events
+  verbs: ["*"]
+
+# Allow listing Namespaces and ServiceAccounts
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - serviceaccounts
+  verbs: ["list", "get", "watch"]
+
+# Allow actions on Endpoints
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["create", "watch", "get", "update", "delete", "list"]
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-server
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-server
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-server-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-server
+subjects:
+- kind: ServiceAccount
+  name: nats-server
+  namespace: default


### PR DESCRIPTION
Add basic examples of deploying the bridge on K8S:

```sh
$ kubectl apply -f deploy/rbac.yaml
$ kubectl apply -f deploy/operator.yaml
$ kubectl apply -f deploy/nats-mq.yaml 

$ kubectl logs deployment/nats-mq
2019/04/23 04:08:29.146864 [INF] loading configuration from "/etc/nats-mq/nats-mq.conf"
2019/04/23 04:08:29.147282 [INF] starting MQ-NATS bridge, version 0.5
2019/04/23 04:08:29.147494 [INF] server time is Tue Apr 23 04:08:29 UTC 2019
2019/04/23 04:08:29.147576 [INF] connecting to NATS core
2019/04/23 04:08:29.157530 [INF] skipping NATS streaming connection, not configured
2019/04/23 04:08:29.157545 [INF] monitoring is disabled
```