### PR TITLE
Add NATS user authentication through creds file

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -115,6 +115,7 @@ The bridge makes a single connection to NATS. This connection is shared by all c
 ```yaml
 nats: {
   Servers: ["localhost:4222"],
+  CredsFile: "/etc/nats-creds/user.creds",
   ConnectTimeout: 5000,
   MaxReconnects: 5,
   ReconnectWait: 5000,
@@ -130,6 +131,7 @@ NATS can be configured with the following properties:
 * `tls` - (optional) [TLS configuration](#tls). If the NATS server uses unverified TLS with a valid certificate, this setting isn't required.
 * `username` - (optional)  depending on the NATS server configuration, user name for authentication.
 * `password` - (optional)  depending on the NATS server configuration, password for authentication.
+* `CredsFile` - (optional)  depending on the NATS server configuration, path to user credentials file(.creds).
 
 <a name="stan"></a>
 

--- a/nats-mq/conf/conf.go
+++ b/nats-mq/conf/conf.go
@@ -117,9 +117,10 @@ type NATSConfig struct {
 	ReconnectWait  int //milliseconds
 	MaxReconnects  int
 
-	TLS      TLSConf
-	Username string
-	Password string
+	TLS       TLSConf
+	Username  string
+	Password  string
+	CredsFile string
 }
 
 // NATSStreamingConfig configuration for a STAN connection

--- a/nats-mq/core/bridge.go
+++ b/nats-mq/core/bridge.go
@@ -296,6 +296,10 @@ func (bridge *BridgeServer) connectToNATS() error {
 		options = append(options, nats.ClientCert(config.TLS.Cert, config.TLS.Key))
 	}
 
+	if config.CredsFile != "" {
+		options = append(options, nats.UserCredentials(config.CredsFile))
+	}
+
 	nc, err := nats.Connect(strings.Join(config.Servers, ","),
 		options...,
 	)


### PR DESCRIPTION
This PR adds the option to authenticate the NATS users through creds file while configuring nats-mq bridge.